### PR TITLE
Consistent preserve mask scripts for Redshift

### DIFF
--- a/masking-examples/consistent-format-preserve/redshift-complete-script.sql
+++ b/masking-examples/consistent-format-preserve/redshift-complete-script.sql
@@ -2,11 +2,12 @@
 CREATE SCHEMA IF NOT EXISTS cyral;
 
 -- 2. Create the new function in the target schema:
-CREATE OR REPLACE FUNCTION cyral.consistent_mask(input_string TEXT)
-RETURNS TEXT
+CREATE OR REPLACE FUNCTION cyral.consistent_mask(data ANYELEMENT)
+RETURNS ANYELEMENT
 STABLE
 AS
 $$
+import decimal
 import re
 import string
 from random import Random
@@ -25,13 +26,28 @@ def generate_random_char(random, current_char):
     return current_char
 
 
-def consistent_mask(input_string):
-    random = Random(str(input_string))
-    return "".join(generate_random_char(random, cur_char) for cur_char in input_string)
+def consistent_mask(input_value):
+    random = Random(str(input_value))
+
+    # Boolean testing needs to come before int since boolean is a subclass of int
+    if isinstance(input_value, bool):
+        return random.choice((True, False))
+
+    if isinstance(input_value, str):
+        return "".join(generate_random_char(random, cur_char) for cur_char in input_value)
+
+    if isinstance(input_value, (int, float, decimal.Decimal)):
+        value_type = type(input_value)
+        if int(input_value) <= 0:
+            return value_type(random.randint(1, 10))
+        return value_type(random.randrange(int(input_value)))
+
+    # We have no idea what to do so we return NULL
+    return None
 
 
-return consistent_mask(input_string)
+return consistent_mask(data)
 $$ LANGUAGE plpythonu;
 
 -- 3. Grant the execution privilege to everyone, through the PUBLIC role
-GRANT EXECUTE ON FUNCTION cyral.consistent_mask(input_string TEXT) TO PUBLIC;
+GRANT EXECUTE ON FUNCTION cyral.consistent_mask(data ANYELEMENT) TO PUBLIC;

--- a/masking-examples/consistent-format-preserve/redshift-udf-only.sql
+++ b/masking-examples/consistent-format-preserve/redshift-udf-only.sql
@@ -1,8 +1,9 @@
-CREATE OR REPLACE FUNCTION ${SCHEMA}.consistent_mask(input_string TEXT)
-RETURNS TEXT
+CREATE OR REPLACE FUNCTION ${SCHEMA}.consistent_mask(data ANYELEMENT)
+RETURNS ANYELEMENT
 STABLE
 AS
 $$
+import decimal
 import re
 import string
 from random import Random
@@ -21,10 +22,25 @@ def generate_random_char(random, current_char):
     return current_char
 
 
-def consistent_mask(input_string):
-    random = Random(str(input_string))
-    return "".join(generate_random_char(random, cur_char) for cur_char in input_string)
+def consistent_mask(input_value):
+    random = Random(str(input_value))
+
+    # Boolean testing needs to come before int since boolean is a subclass of int
+    if isinstance(input_value, bool):
+        return random.choice((True, False))
+
+    if isinstance(input_value, str):
+        return "".join(generate_random_char(random, cur_char) for cur_char in input_value)
+
+    if isinstance(input_value, (int, float, decimal.Decimal)):
+        value_type = type(input_value)
+        if int(input_value) <= 0:
+            return value_type(random.randint(1, 10))
+        return value_type(random.randrange(int(input_value)))
+
+    # We have no idea what to do so we return NULL
+    return None
 
 
-return consistent_mask(input_string)
+return consistent_mask(data)
 $$ LANGUAGE plpythonu;


### PR DESCRIPTION
```sql
select cyral.consistent_mask('aaa.BBB.5555'::text),
cyral.consistent_mask(999),
cyral.consistent_mask(999.9999),
cyral.consistent_mask(999.9999::float),
cyral.consistent_mask(999.9999::double precision),
cyral.consistent_mask(-999.9999),
cyral.consistent_mask(-999.9999::numeric(20, 4))
union all
select cyral.consistent_mask('aaa.BBB.5555'::text),
cyral.consistent_mask(999),
cyral.consistent_mask(999.9999),
cyral.consistent_mask(999.9999::float),
cyral.consistent_mask(999.9999::double precision),
cyral.consistent_mask(-999.9999),
cyral.consistent_mask(-999.9999::numeric(20, 4))
union all
select cyral.consistent_mask('cccc.DDD.6666'::text),
cyral.consistent_mask(888),
cyral.consistent_mask(888.8888),
cyral.consistent_mask(888.8888::float),
cyral.consistent_mask(888.8888::double precision),
cyral.consistent_mask(-888.8888),
cyral.consistent_mask(-888.8888::numeric(20, 4));
```
![image](https://github.com/cyral-quickstart/quickstart-datarepo-masking/assets/31210195/045627a6-0760-43b7-a136-3f2dcc84d27d)



